### PR TITLE
Add option to resolve plugins relative to input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
+!fixtures/node_modules
 npm-debug.log

--- a/README.md
+++ b/README.md
@@ -73,6 +73,16 @@ Note that you may also set this option to `'*'` to disable whitelisting of
 modules. This is not recommended for environments where you may be accepting
 arbitrary user input; use at your own risk.
 
+##### resolvePluginsRelativeToFile
+
+Type: `boolean` (default: `false`)
+
+Set this to true in order to resolve plugins relative to the file that referenced them. This enables the usage of different versions of the same plugin, for instance.
+
+```js
+postcss([ use({ resolvePluginsRelativeToFile: true, modules: '*' }) ]);
+```
+
 ## Usage
 
 See the [PostCSS documentation](https://github.com/postcss/postcss#usage) for

--- a/README.md
+++ b/README.md
@@ -73,14 +73,14 @@ Note that you may also set this option to `'*'` to disable whitelisting of
 modules. This is not recommended for environments where you may be accepting
 arbitrary user input; use at your own risk.
 
-##### resolvePluginsRelativeToFile
+##### resolveFromFile
 
 Type: `boolean` (default: `false`)
 
 Set this to true in order to resolve plugins relative to the file that referenced them. This enables the usage of different versions of the same plugin, for instance.
 
 ```js
-postcss([ use({ resolvePluginsRelativeToFile: true, modules: '*' }) ]);
+postcss([ use({ resolveFromFile: true, modules: '*' }) ]);
 ```
 
 ## Usage

--- a/fixtures/node_modules/postcss-nobg/index.js
+++ b/fixtures/node_modules/postcss-nobg/index.js
@@ -1,0 +1,11 @@
+'use strict';
+
+var postcss = require('postcss');
+
+module.exports = postcss.plugin('nobg', function () {
+    return function nobg (css) {
+        css.walkDecls(/^background/, function (decl) {
+            decl.remove();
+        });
+    };
+});

--- a/fixtures/node_modules/postcss-nobg/package.json
+++ b/fixtures/node_modules/postcss-nobg/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "postcss-nobg",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/fixtures/test.css
+++ b/fixtures/test.css
@@ -1,0 +1,3 @@
+@use postcss-nobg;
+
+.foo {background: blue;color: red;}

--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
 'use strict';
 
+var path = require('path');
 var postcss = require('postcss');
 var balanced = require('balanced-match');
+var resolveFrom = require('resolve-from');
 
 function trim (value) {
     return value.trim();
@@ -78,7 +80,12 @@ module.exports = postcss.plugin('postcss-use', function (opts) {
             // Remove any directory traversal
             plugin = plugin.replace(/\.\/\\/g, '');
             if (~opts.modules.indexOf(plugin) || opts.modules === '*') {
-                var instance = require(plugin)(pluginOpts);
+                var pluginPath;
+                if (opts.resolvePluginsRelativeToFile && rule.source.input.file) {
+                    pluginPath = resolveFrom(path.dirname(rule.source.input.file), plugin);
+                }
+
+                var instance = require(pluginPath || plugin)(pluginOpts);
                 if (instance.plugins) {
                     instance.plugins.forEach(function (p) {
                         result.processor.plugins.push(p);

--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ module.exports = postcss.plugin('postcss-use', function (opts) {
             plugin = plugin.replace(/\.\/\\/g, '');
             if (~opts.modules.indexOf(plugin) || opts.modules === '*') {
                 var pluginPath;
-                if (opts.resolvePluginsRelativeToFile && rule.source.input.file) {
+                if (opts.resolveFromFile && rule.source.input.file) {
                     pluginPath = resolveFrom(path.dirname(rule.source.input.file), plugin);
                 }
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "repository": "postcss/postcss-use",
   "dependencies": {
     "balanced-match": "^0.4.1",
-    "postcss": "^5.0.21"
+    "postcss": "^5.0.21",
+    "resolve-from": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "repository": "postcss/postcss-use",
   "dependencies": {
-    "balanced-match": "^0.3.0",
-    "postcss": "^5.0.14"
+    "balanced-match": "^0.4.1",
+    "postcss": "^5.0.21"
   }
 }

--- a/test.js
+++ b/test.js
@@ -28,7 +28,7 @@ var tests = [{
 }, {
     message: 'should enable autoprefixer from css',
     fixture: '@use autoprefixer (remove: false; browsers: "> 1%, firefox 32");main{-webkit-border-radius:10px;border-radius:10px;display:flex;}',
-    expected: 'main{-webkit-border-radius:10px;border-radius:10px;display:-webkit-box;display:-webkit-flex;display:flex;}',
+    expected: 'main{-webkit-border-radius:10px;border-radius:10px;display:-webkit-box;display:flex;}',
     options: {modules: ['autoprefixer']}
 }, {
     message: 'should enable autoprefixer from css, with nested options',

--- a/test.js
+++ b/test.js
@@ -102,11 +102,11 @@ tape('should use the postcss plugin api', function (t) {
     t.equal(plugin().postcssPlugin, name, 'should be able to access name');
 });
 
-tape('should use plugins relative to CSS file when using resolvePluginsRelativeToFile', function (t) {
+tape('should use plugins relative to CSS file when using resolveFromFile', function (t) {
     var inputFile = path.join(__dirname, 'fixtures', 'test.css');
     var outputFile = path.join(__dirname, 'fixtures', 'test.out.css');
     var inputCss = fs.readFileSync(inputFile);
-    postcss(plugin({modules: '*', resolvePluginsRelativeToFile: true})).process(inputCss, {
+    postcss(plugin({modules: '*', resolveFromFile: true})).process(inputCss, {
         from: inputFile,
         to: outputFile
     }).then(function (result) {


### PR DESCRIPTION
In some cases, it makes sense to resolve plugins relative to the CSS file that referenced it. One case is where you might have two different versions of a plugin, the other (which is our case) is where you have some tooling which abstracts the build process. In this case, when postcss-use tries to require a plugin, the paths it is using is not necessarily within the same project.

I've added an option, `resolvePluginsRelativeToFile` (a bit verbose, I know) which uses `resolve-from` to figure out the path to the plugins relative to the source file. Sorry about the fixtures I've added, but couldn't come up with anything cleaner.

Any thoughts? Happy to adjust naming or method used.
