### PR TITLE
Fix error message when resolving relative and module is not found

### DIFF
--- a/fixtures/error.css
+++ b/fixtures/error.css
@@ -1,0 +1,3 @@
+@use postcss-fourohfour;
+
+.foo {background: blue;color: red;}

--- a/index.js
+++ b/index.js
@@ -85,6 +85,10 @@ module.exports = postcss.plugin('postcss-use', function (opts) {
                     pluginPath = resolveFrom(path.dirname(rule.source.input.file), plugin);
                 }
 
+                if (!pluginPath) {
+                    throw new Error('Cannot find module \'' + plugin + '\'');
+                }
+
                 var instance = require(pluginPath)(pluginOpts);
                 if (instance.plugins) {
                     instance.plugins.forEach(function (p) {

--- a/test.js
+++ b/test.js
@@ -115,6 +115,21 @@ tape('should use plugins relative to CSS file when using resolveFromFile', funct
     }).catch(t.ifError);
 });
 
+tape('should give meaningful error when module is not found', function (t) {
+    var inputFile = path.join(__dirname, 'fixtures', 'error.css');
+    var outputFile = path.join(__dirname, 'fixtures', 'error.out.css');
+    var inputCss = fs.readFileSync(inputFile);
+    postcss(plugin({modules: '*', resolveFromFile: true})).process(inputCss, {
+        from: inputFile,
+        to: outputFile
+    }).then(function () {
+        t.fail('Should fail when referencing plugin that is not installed');
+    }).catch(function (err) {
+        t.equal(err.message, 'Cannot find module \'postcss-fourohfour\'');
+        t.end();
+    });
+});
+
 tape('should not resolve plugins relative to CSS file by default', function (t) {
     var inputFile = path.join(__dirname, 'fixtures', 'test.css');
     var outputFile = path.join(__dirname, 'fixtures', 'test.out.css');


### PR DESCRIPTION
Currently, if you use the relative require option and the plugin you are trying to use does not exist, you get a very cryptic `missing path` error (because the path can't be resolved, it returns `null` and `require(null)` gives this message.

This PR fixes this by explicitly throwing if no path to plugin is found.