### PR TITLE
Add option to specify default plugin options (closes #11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,25 @@ plugin, for instance.
 postcss([ use({ resolveFromFile: true, modules: '*' }) ]);
 ```
 
+##### defaultPluginOptions
+
+Type: `object` (default: `{}`)
+
+Default options for plugins, keyed by plugin name. If both the default and the specified options are objects, they are merged. Otherwise, the options specified in the CSS are used.
+
+```js
+postcss([
+    use({
+        modules: '*',
+        defaultPluginOptions: {
+            autoprefixer: {
+                browsers: ['> 1%', 'IE 7']
+            }
+        }
+    })
+]);
+```
+
 ## Usage
 
 See the [PostCSS documentation](https://github.com/postcss/postcss#usage) for

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ plugin, for instance.
 postcss([ use({ resolveFromFile: true, modules: '*' }) ]);
 ```
 
-##### defaultPluginOptions
+##### options
 
 Type: `object` (default: `{}`)
 
@@ -95,7 +95,7 @@ Default options for plugins, keyed by plugin name. If both the default and the s
 postcss([
     use({
         modules: '*',
-        defaultPluginOptions: {
+        options: {
             autoprefixer: {
                 browsers: ['> 1%', 'IE 7']
             }

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   "repository": "postcss/postcss-use",
   "dependencies": {
     "balanced-match": "^0.4.1",
+    "lodash.isplainobject": "^4.0.6",
     "postcss": "^5.0.21",
     "resolve-from": "^2.0.0"
   },

--- a/src/__tests__/fixtures/arrayOptions.css
+++ b/src/__tests__/fixtures/arrayOptions.css
@@ -1,0 +1,10 @@
+@use postcss-nobg(["background-repeat"]);
+
+.foo {
+    background-image: url(/foo.jpg);
+}
+
+.bar {
+    background: #bf1942;
+    background-repeat: no-repeat;
+}

--- a/src/__tests__/fixtures/node_modules/postcss-nobg/index.js
+++ b/src/__tests__/fixtures/node_modules/postcss-nobg/index.js
@@ -1,11 +1,26 @@
+/* eslint-disable strict, prefer-arrow-callback, no-var */
 'use strict';
 
 var postcss = require('postcss');
 
-module.exports = postcss.plugin('nobg', function () {
+module.exports = postcss.plugin('nobg', function (opts) {
+    var options = opts || {};
     return function nobg (css) {
-        css.walkDecls(/^background/, function (decl) {
-            decl.remove();
+        var matchers = [/^background/];
+        // Let's pretend this is a new release which has to support an
+        // earlier API where you explicitly defined declarations
+        if (Array.isArray(options)) {
+            matchers = options.map(function (decl) {
+                return new RegExp('^' + decl + '$');
+            });
+        } else if (options.onlyImages) {
+            matchers = [/^background-image/];
+        }
+
+        matchers.forEach(function (matcher) {
+            css.walkDecls(matcher, function (decl) {
+                decl.remove();
+            });
         });
     };
 });

--- a/src/__tests__/fixtures/options.css
+++ b/src/__tests__/fixtures/options.css
@@ -1,0 +1,9 @@
+@use postcss-nobg(onlyImages: false);
+
+.foo {
+    background-image: url(/foo.jpg);
+}
+
+.bar {
+    background: #bf1942;
+}

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -125,3 +125,52 @@ test('should not resolve plugins relative to CSS file by default', t => {
         t.deepEqual(err.message, `Cannot find module 'postcss-nobg'`);
     });
 });
+
+test('should be able to specify default options for plugins', t => {
+    const inputFile = path.join(__dirname, 'fixtures', 'test.css');
+    const outputFile = path.join(__dirname, 'fixtures', 'test.out.css');
+    const inputCss = fs.readFileSync(inputFile);
+    const defaultPluginOptions = {
+        nobg: {onlyImages: true},
+    };
+    return postcss(plugin({modules: '*', resolveFromFile: true, defaultPluginOptions})).process(inputCss, {
+        from: inputFile,
+        to: outputFile,
+    }).then(({css}) => {
+        const normalized = css.replace(/\s+/g, ' ').trim();
+        t.deepEqual(normalized, '.foo {background: blue;color: red;}', 'should remove only background image decls');
+    });
+});
+
+test('should be able to override default options', t => {
+    const inputFile = path.join(__dirname, 'fixtures', 'options.css');
+    const outputFile = path.join(__dirname, 'fixtures', 'options.out.css');
+    const inputCss = fs.readFileSync(inputFile);
+    const defaultPluginOptions = {
+        nobg: {onlyImages: true},
+    };
+    return postcss(plugin({modules: '*', resolveFromFile: true, defaultPluginOptions})).process(inputCss, {
+        from: inputFile,
+        to: outputFile,
+    }).then(({css}) => {
+        const normalized = css.replace(/\s+/g, ' ').trim();
+        t.deepEqual(normalized, '.foo { } .bar { }', 'should remove only background image decls');
+    });
+});
+
+test('should use specified options if specified options is not an object', t => {
+    const inputFile = path.join(__dirname, 'fixtures', 'arrayOptions.css');
+    const outputFile = path.join(__dirname, 'fixtures', 'arrayOptions.out.css');
+    const inputCss = fs.readFileSync(inputFile);
+    const defaultPluginOptions = {
+        nobg: {onlyImages: true},
+    };
+    return postcss(plugin({modules: '*', resolveFromFile: true, defaultPluginOptions})).process(inputCss, {
+        from: inputFile,
+        to: outputFile,
+    }).then(({css}) => {
+        const normalized = css.replace(/\s+/g, ' ').trim();
+        const expected = '.foo { background-image: url(/foo.jpg); } .bar { background: #bf1942; }';
+        t.deepEqual(normalized, expected, 'should remove only background-repeat decls');
+    });
+});

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -130,10 +130,10 @@ test('should be able to specify default options for plugins', t => {
     const inputFile = path.join(__dirname, 'fixtures', 'test.css');
     const outputFile = path.join(__dirname, 'fixtures', 'test.out.css');
     const inputCss = fs.readFileSync(inputFile);
-    const defaultPluginOptions = {
+    const options = {
         nobg: {onlyImages: true},
     };
-    return postcss(plugin({modules: '*', resolveFromFile: true, defaultPluginOptions})).process(inputCss, {
+    return postcss(plugin({modules: '*', resolveFromFile: true, options})).process(inputCss, {
         from: inputFile,
         to: outputFile,
     }).then(({css}) => {
@@ -146,10 +146,10 @@ test('should be able to override default options', t => {
     const inputFile = path.join(__dirname, 'fixtures', 'options.css');
     const outputFile = path.join(__dirname, 'fixtures', 'options.out.css');
     const inputCss = fs.readFileSync(inputFile);
-    const defaultPluginOptions = {
+    const options = {
         nobg: {onlyImages: true},
     };
-    return postcss(plugin({modules: '*', resolveFromFile: true, defaultPluginOptions})).process(inputCss, {
+    return postcss(plugin({modules: '*', resolveFromFile: true, options})).process(inputCss, {
         from: inputFile,
         to: outputFile,
     }).then(({css}) => {
@@ -162,10 +162,10 @@ test('should use specified options if specified options is not an object', t => 
     const inputFile = path.join(__dirname, 'fixtures', 'arrayOptions.css');
     const outputFile = path.join(__dirname, 'fixtures', 'arrayOptions.out.css');
     const inputCss = fs.readFileSync(inputFile);
-    const defaultPluginOptions = {
+    const options = {
         nobg: {onlyImages: true},
     };
-    return postcss(plugin({modules: '*', resolveFromFile: true, defaultPluginOptions})).process(inputCss, {
+    return postcss(plugin({modules: '*', resolveFromFile: true, options})).process(inputCss, {
         from: inputFile,
         to: outputFile,
     }).then(({css}) => {

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,18 @@ import isPlainObject from 'lodash.isplainobject';
 
 const NAME = 'postcss-use';
 
+const assign = Object.assign || function (target) {
+    for (let i = 1; i < arguments.length; i++) {
+        const source = arguments[i];
+        for (const key in source) {
+            if (Object.prototype.hasOwnProperty.call(source, key)) {
+                target[key] = source[key];
+            }
+        }
+    }
+    return target;
+};
+
 function invalidOption (option) {
     throw new SyntaxError(`Invalid option '${option}'`);
 }
@@ -39,7 +51,7 @@ function mergePluginOptions (plugin, defaultOpts, specifiedOpts) {
     }
 
     // If both the default and specified options are plain objects, we can merge them
-    return Object.assign({}, defaultOpts, specifiedOpts);
+    return assign({}, defaultOpts, specifiedOpts);
 }
 
 export default postcss.plugin(NAME, (opts = {}) => {

--- a/src/index.js
+++ b/src/index.js
@@ -6,18 +6,6 @@ import isPlainObject from 'lodash.isplainobject';
 
 const NAME = 'postcss-use';
 
-const assign = Object.assign || function (target) {
-    for (let i = 1; i < arguments.length; i++) {
-        const source = arguments[i];
-        for (const key in source) {
-            if (Object.prototype.hasOwnProperty.call(source, key)) {
-                target[key] = source[key];
-            }
-        }
-    }
-    return target;
-};
-
 function invalidOption (option) {
     throw new SyntaxError(`Invalid option '${option}'`);
 }
@@ -51,7 +39,7 @@ function mergePluginOptions (plugin, defaultOpts, specifiedOpts) {
     }
 
     // If both the default and specified options are plain objects, we can merge them
-    return assign({}, defaultOpts, specifiedOpts);
+    return {...defaultOpts, ...specifiedOpts};
 }
 
 export default postcss.plugin(NAME, (opts = {}) => {

--- a/src/index.js
+++ b/src/index.js
@@ -112,7 +112,7 @@ export default postcss.plugin(NAME, (opts = {}) => {
                 }
 
                 let optsName = plugin.replace(/^postcss-/, '');
-                let defaultOpts = (opts.defaultPluginOptions && opts.defaultPluginOptions[optsName]) || {};
+                let defaultOpts = (opts.options && opts.options[optsName]) || {};
                 let mergedOptions = mergePluginOptions(optsName, defaultOpts, pluginOpts);
                 let instance = require(pluginPath)(mergedOptions);
                 if (instance.plugins) {


### PR DESCRIPTION
As outlined in #11, it would be useful to be able to provide default options for plugins.

This implements that. I couldn't see any good way to merge non-object options, such as arrays - it's unclear whether it's meant to override or merge them when this is the case.
